### PR TITLE
added num_workers = 0 at ImageDataLoaders.from_name_func function

### DIFF
--- a/01_intro.ipynb
+++ b/01_intro.ipynb
@@ -574,7 +574,7 @@
     "def is_cat(x): return x[0].isupper()\n",
     "dls = ImageDataLoaders.from_name_func(\n",
     "    path, get_image_files(path), valid_pct=0.2, seed=42,\n",
-    "    label_func=is_cat, item_tfms=Resize(224))\n",
+    "    label_func=is_cat, item_tfms=Resize(224), num_workers = 0)\n",
     "\n",
     "learn = cnn_learner(dls, resnet34, metrics=error_rate)\n",
     "learn.fine_tune(1)"


### PR DESCRIPTION
`ImageDataLoader.from_name_func(path, get_image_files(path), valid_pct, seed, label_func, item_tfms)` 
requires another parameter to be specified i.e `num_workers = 0` after which only it works in colab